### PR TITLE
Fix Android Debug APK Firebase workflow

### DIFF
--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -60,13 +60,13 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "::warning::Firebase configuration not available; Firebase features will be disabled for this debug/development APK build."
+            echo "::warning::Firebase configuration not available; Firebase features will be disabled for this debug/development APK build. Set ANDROID_GOOGLE_SERVICES_JSON_BASE64 to enable Firebase."
             echo "google_services_restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if ! printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json; then
-            echo "Error: Failed to restore android/app/google-services.json from ANDROID_GOOGLE_SERVICES_JSON_BASE64."
+            echo "Error: Failed to restore android/app/google-services.json from ANDROID_GOOGLE_SERVICES_JSON_BASE64. Check that the secret contains valid base64-encoded JSON."
             exit 1
           fi
 
@@ -171,7 +171,7 @@ jobs:
                 echo "APK generated with Firebase disabled."
                 echo
                 echo "This no-firebase fallback is allowed only for debug/development APK builds."
-                echo "Do not mark READY FOR MERGE while Firebase is disabled."
+                echo "A Firebase-enabled run is required before marking READY FOR MERGE."
                 ;;
             esac
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -65,13 +65,10 @@ jobs:
             exit 0
           fi
 
-          google_services_json_base64="$ANDROID_GOOGLE_SERVICES_JSON_BASE64"
-          if ! printf '%s' "$google_services_json_base64" | base64 --decode > android/app/google-services.json; then
+          if ! printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json; then
             echo "Error: Failed to decode ANDROID_GOOGLE_SERVICES_JSON_BASE64. Verify the secret contains valid base64-encoded content."
             exit 1
           fi
-
-          test -s android/app/google-services.json
 
           node <<'NODE'
           const fs = require('fs');
@@ -167,20 +164,16 @@ jobs:
             echo
             echo "Artifact: MeetYouLive-debug-${{ github.run_number }}"
             echo
-            case "$GOOGLE_SERVICES_RESTORED" in
-              true)
-                echo "APK generated with Firebase enabled."
-                ;;
-              false)
-                echo "APK generated with Firebase disabled."
-                echo
-                echo "This no-firebase fallback is allowed only for debug/development APK builds."
-                echo "Do not mark READY FOR MERGE from this disabled-Firebase debug run."
-                ;;
-              *)
-                echo "Unexpected Firebase restore status: $GOOGLE_SERVICES_RESTORED"
-                exit 1
-                ;;
-            esac
+            if [ "$GOOGLE_SERVICES_RESTORED" = "true" ]; then
+              echo "APK generated with Firebase enabled."
+            elif [ "$GOOGLE_SERVICES_RESTORED" = "false" ]; then
+              echo "APK generated with Firebase disabled."
+              echo
+              echo "This no-firebase fallback is allowed only for debug/development APK builds."
+              echo "Do not mark READY FOR MERGE from this disabled-Firebase debug run."
+            else
+              echo "Unexpected Firebase restore status: $GOOGLE_SERVICES_RESTORED"
+              exit 1
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
         shell: bash

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -86,12 +86,12 @@ jobs:
           try {
             const data = JSON.parse(raw);
             if (!data || typeof data !== 'object' || Array.isArray(data)) {
-              console.error('Error: google-services.json must contain a non-empty JSON object.');
+              console.error('Error: google-services.json must contain a JSON object.');
               process.exit(1);
             }
 
             if (Object.keys(data).length === 0) {
-              console.error('Error: google-services.json must contain a non-empty JSON object.');
+              console.error('Error: google-services.json must not be an empty JSON object.');
               process.exit(1);
             }
 
@@ -171,7 +171,7 @@ jobs:
               true)
                 echo "APK generated with Firebase enabled."
                 ;;
-              false|"")
+              false)
                 echo "APK generated with Firebase disabled."
                 echo
                 echo "This no-firebase fallback is allowed only for debug/development APK builds."

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -93,7 +93,7 @@ jobs:
             }
 
             if (!data.project_info || !Array.isArray(data.client) || data.client.length === 0) {
-              console.error('Error: google-services.json is missing required Firebase project_info or client fields.');
+              console.error('Error: google-services.json must contain both project_info and a non-empty client array.');
               process.exit(1);
             }
           } catch (error) {
@@ -170,7 +170,7 @@ jobs:
               echo "APK generated with Firebase disabled."
               echo
               echo "This no-firebase fallback is allowed only for debug/development APK builds."
-              echo "Do not mark READY FOR MERGE from this disabled-Firebase debug run."
+              echo "Do not treat this disabled-Firebase debug run as ready for merge."
             else
               echo "Unexpected Firebase restore status: $GOOGLE_SERVICES_RESTORED"
               exit 1

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -85,19 +85,13 @@ jobs:
 
           try {
             const data = JSON.parse(raw);
-            if (data === null || data === undefined) {
-              console.error('Error: google-services.json must contain a non-empty JSON value.');
+            if (!data || typeof data !== 'object' || Array.isArray(data)) {
+              console.error('Error: google-services.json must contain a non-empty JSON object.');
               process.exit(1);
             }
 
-            const isEmptyArray = Array.isArray(data) && data.length === 0;
-            const isEmptyObject =
-              typeof data === 'object' &&
-              !Array.isArray(data) &&
-              Object.keys(data).length === 0;
-
-            if (isEmptyArray || isEmptyObject) {
-              console.error('Error: google-services.json must contain a non-empty JSON value.');
+            if (Object.keys(data).length === 0) {
+              console.error('Error: google-services.json must contain a non-empty JSON object.');
               process.exit(1);
             }
 
@@ -177,11 +171,15 @@ jobs:
               true)
                 echo "APK generated with Firebase enabled."
                 ;;
-              *)
+              false|"")
                 echo "APK generated with Firebase disabled."
                 echo
                 echo "This no-firebase fallback is allowed only for debug/development APK builds."
                 echo "Do not mark READY FOR MERGE from this disabled-Firebase debug run."
+                ;;
+              *)
+                echo "Unexpected Firebase restore status: $GOOGLE_SERVICES_RESTORED"
+                exit 1
                 ;;
             esac
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -65,7 +65,8 @@ jobs:
             exit 0
           fi
 
-          if ! printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json; then
+          google_services_json_base64="$ANDROID_GOOGLE_SERVICES_JSON_BASE64"
+          if ! printf '%s' "$google_services_json_base64" | base64 --decode > android/app/google-services.json; then
             echo "Error: Failed to decode ANDROID_GOOGLE_SERVICES_JSON_BASE64. Verify the secret contains valid base64-encoded content."
             exit 1
           fi
@@ -84,7 +85,7 @@ jobs:
 
           try {
             const data = JSON.parse(raw);
-            if (data == null) {
+            if (data === null || data === undefined) {
               console.error('Error: google-services.json must contain a non-empty JSON value.');
               process.exit(1);
             }
@@ -97,6 +98,11 @@ jobs:
 
             if (isEmptyArray || isEmptyObject) {
               console.error('Error: google-services.json must contain a non-empty JSON value.');
+              process.exit(1);
+            }
+
+            if (!data.project_info || !Array.isArray(data.client) || data.client.length === 0) {
+              console.error('Error: google-services.json is missing required Firebase project_info or client fields.');
               process.exit(1);
             }
           } catch (error) {

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -60,13 +60,13 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "::warning::Firebase configuration not available; Firebase features will be disabled for this debug/development APK build. Set ANDROID_GOOGLE_SERVICES_JSON_BASE64 to enable Firebase."
+            echo "::warning::Firebase config missing; debug build will proceed without Firebase. Set ANDROID_GOOGLE_SERVICES_JSON_BASE64 to enable."
             echo "google_services_restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if ! printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json; then
-            echo "Error: Failed to restore android/app/google-services.json from ANDROID_GOOGLE_SERVICES_JSON_BASE64. Check that the secret contains valid base64-encoded JSON."
+            echo "Error: Failed to decode ANDROID_GOOGLE_SERVICES_JSON_BASE64. Verify the secret contains valid base64-encoded content."
             exit 1
           fi
 
@@ -84,14 +84,18 @@ jobs:
 
           try {
             const data = JSON.parse(raw);
+            if (data == null) {
+              console.error('Error: google-services.json must contain a non-empty JSON value.');
+              process.exit(1);
+            }
+
             const isEmptyArray = Array.isArray(data) && data.length === 0;
             const isEmptyObject =
-              data &&
               typeof data === 'object' &&
               !Array.isArray(data) &&
               Object.keys(data).length === 0;
 
-            if (data == null || isEmptyArray || isEmptyObject) {
+            if (isEmptyArray || isEmptyObject) {
               console.error('Error: google-services.json must contain a non-empty JSON value.');
               process.exit(1);
             }
@@ -171,7 +175,7 @@ jobs:
                 echo "APK generated with Firebase disabled."
                 echo
                 echo "This no-firebase fallback is allowed only for debug/development APK builds."
-                echo "A Firebase-enabled run is required before marking READY FOR MERGE."
+                echo "Do not mark READY FOR MERGE from this disabled-Firebase debug run."
                 ;;
             esac
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "::warning::Firebase config missing; debug build will proceed without Firebase. Set ANDROID_GOOGLE_SERVICES_JSON_BASE64 to enable."
+            echo "::warning::Firebase config missing; debug build will proceed without Firebase. Production/release builds must configure ANDROID_GOOGLE_SERVICES_JSON_BASE64."
             echo "google_services_restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -92,8 +92,18 @@ jobs:
               process.exit(1);
             }
 
-            if (!data.project_info || !Array.isArray(data.client) || data.client.length === 0) {
-              console.error('Error: google-services.json must contain both project_info and a non-empty client array.');
+            if (!data.project_info) {
+              console.error('Error: google-services.json must contain project_info.');
+              process.exit(1);
+            }
+
+            if (!Array.isArray(data.client)) {
+              console.error('Error: google-services.json client must be an array.');
+              process.exit(1);
+            }
+
+            if (data.client.length === 0) {
+              console.error('Error: google-services.json client array must not be empty.');
               process.exit(1);
             }
           } catch (error) {

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: frontend
         run: |
           set -euo pipefail
-          if [ -z "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
+          if [ -z "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" ]; then
             echo "::warning::Firebase config missing; debug build will proceed without Firebase. Production/release builds must configure ANDROID_GOOGLE_SERVICES_JSON_BASE64."
             echo "google_services_restored=false" >> "$GITHUB_OUTPUT"
             exit 0
@@ -94,6 +94,11 @@ jobs:
 
             if (!data.project_info) {
               console.error('Error: google-services.json must contain project_info.');
+              process.exit(1);
+            }
+
+            if (!data.client) {
+              console.error('Error: google-services.json must contain client.');
               process.exit(1);
             }
 

--- a/.github/workflows/android-debug-apk.yml
+++ b/.github/workflows/android-debug-apk.yml
@@ -55,25 +55,63 @@ jobs:
         run: npm ci
 
       - name: Restore Firebase google-services.json
+        id: restore_google_services
         working-directory: frontend
         run: |
           set -euo pipefail
           if [ -z "${ANDROID_GOOGLE_SERVICES_JSON_BASE64:-}" ]; then
-            echo "::warning::ANDROID_GOOGLE_SERVICES_JSON_BASE64 is not configured; building debug APK without native Firebase push."
+            echo "::warning::Firebase configuration not available; Firebase features will be disabled for this debug/development APK build."
+            echo "google_services_restored=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json
+
+          if ! printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > android/app/google-services.json; then
+            echo "Error: Failed to restore android/app/google-services.json from ANDROID_GOOGLE_SERVICES_JSON_BASE64."
+            exit 1
+          fi
+
           test -s android/app/google-services.json
+
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'android/app/google-services.json';
+          const raw = fs.readFileSync(path, 'utf8').trim();
+
+          if (!raw) {
+            console.error('Error: google-services.json is empty.');
+            process.exit(1);
+          }
+
+          try {
+            const data = JSON.parse(raw);
+            const isEmptyArray = Array.isArray(data) && data.length === 0;
+            const isEmptyObject =
+              data &&
+              typeof data === 'object' &&
+              !Array.isArray(data) &&
+              Object.keys(data).length === 0;
+
+            if (data == null || isEmptyArray || isEmptyObject) {
+              console.error('Error: google-services.json must contain a non-empty JSON value.');
+              process.exit(1);
+            }
+          } catch (error) {
+            console.error(`Error: Invalid google-services.json (${error.message}).`);
+            process.exit(1);
+          }
+          NODE
+
+          echo "google_services_restored=true" >> "$GITHUB_OUTPUT"
         env:
           ANDROID_GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON_BASE64 }}
+        shell: bash
 
-      - name: Check Firebase config availability
+      - name: Verify Firebase config was restored
+        if: steps.restore_google_services.outputs.google_services_restored == 'true'
         working-directory: frontend
         run: |
-          set -euo pipefail
-          if [ ! -s android/app/google-services.json ]; then
-            echo "::warning::ANDROID_GOOGLE_SERVICES_JSON_BASE64 is not configured; building debug APK without native Firebase push."
-          fi
+          test -s android/app/google-services.json
+        shell: bash
 
       # Capacitor sync generates the gitignored files that Gradle needs:
       #   - android/capacitor-cordova-android-plugins/
@@ -105,6 +143,7 @@ jobs:
         if: always()
         working-directory: frontend
         run: rm -f android/app/google-services.json
+        shell: bash
 
       - name: Upload Debug APK artifact
         uses: actions/upload-artifact@v4
@@ -114,3 +153,26 @@ jobs:
           path: frontend/android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 30
           if-no-files-found: error
+
+      - name: Report APK Firebase status
+        env:
+          GOOGLE_SERVICES_RESTORED: ${{ steps.restore_google_services.outputs.google_services_restored }}
+        run: |
+          {
+            echo "## Android Debug APK"
+            echo
+            echo "Artifact: MeetYouLive-debug-${{ github.run_number }}"
+            echo
+            case "$GOOGLE_SERVICES_RESTORED" in
+              true)
+                echo "APK generated with Firebase enabled."
+                ;;
+              *)
+                echo "APK generated with Firebase disabled."
+                echo
+                echo "This no-firebase fallback is allowed only for debug/development APK builds."
+                echo "Do not mark READY FOR MERGE while Firebase is disabled."
+                ;;
+            esac
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash


### PR DESCRIPTION
## Summary

- Base branch: main
- Fix Android Debug APK workflow
- Restore google-services.json only when the GitHub secret ANDROID_GOOGLE_SERVICES_JSON_BASE64 exists
- Keep Firebase fallback only for debug/development builds
- Report whether the APK was generated with Firebase enabled or disabled
- Preserve cleanup of google-services.json after the build

## Validation

- YAML validated
- Secret scan passed
- Ready for GitHub Actions validation