### PR TITLE
Send auth token on creator profile fetch

### DIFF
--- a/frontend/app/creator/[id]/page.jsx
+++ b/frontend/app/creator/[id]/page.jsx
@@ -8,6 +8,7 @@ import ExclusiveContent from "@/components/ExclusiveContent";
 import ProfileGiftStats from "@/components/ProfileGiftStats";
 import { getDisplayName } from "@/lib/imageHelpers";
 import { isApprovedCreator } from "@/lib/creatorUtils";
+import { getToken } from "@/lib/token";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
@@ -21,7 +22,9 @@ export default function CreatorProfilePage() {
   useEffect(() => {
     if (!id) return;
     setLoading(true);
-    fetch(`${API_URL}/api/user/${id}/public`)
+    const token = getToken();
+    const headers = token ? { Authorization: "Bearer " + token } : undefined;
+    fetch(`${API_URL}/api/user/${id}/public`, { headers })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();


### PR DESCRIPTION
## Bug corregido

La página `/creator/:id` consultaba `GET /api/user/:id/public` sin enviar el token de autenticación.

Esto podía impedir que el backend aplicara correctamente la protección de bloqueo bilateral para usuarios autenticados.

## Solución

Enviar el token de autenticación existente en la solicitud del perfil de creador.

## Alcance

Cambio mínimo y limitado a este problema.

- No se modifica el endpoint backend.
- No se modifica Feed.
- No se modifica Discover.
- No se modifica Like/Dislike.
- No se modifica el sistema global de autenticación.
- No se modifican sistemas protegidos.

## Nota de validación

Copilot guardó la corrección en la rama, pero la ejecución del agente terminó inesperadamente durante la fase de validación.

Revisar los checks normales del PR antes del merge.